### PR TITLE
update: schema updated with new tables

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -194,7 +194,10 @@
 			"#__sppagebuilder_collection_items",
 			"#__sppagebuilder_collection_item_values",
 			"#__sppagebuilder_typography",
-			"#__sppagebuilder_collection_imports"
+			"#__sppagebuilder_collection_imports",
+			"#__sppagebuilder_comments",
+			"#__sppagebuilder_likes",
+			"#__sppagebuilder_versions"
 		],
 		"excludes": [],
 		"data_excludes": []
@@ -320,31 +323,19 @@
 	},
 	"spmoviedb": {
 		"name": "SP Movie Database",
-		"includes": [
-			"#__spmoviedb_movies",
-			"#__spmoviedb_celebrities",
-			"#__spmoviedb_genres",
-			"#__spmoviedb_reviews"
-		],
+		"includes": ["#__spmoviedb_movies", "#__spmoviedb_celebrities", "#__spmoviedb_genres", "#__spmoviedb_reviews"],
 		"excludes": [],
 		"data_excludes": []
 	},
 	"spmedical": {
 		"name": "SP Medical",
-		"includes": [
-			"#__spmedical_departments",
-			"#__spmedical_specialists",
-			"#__spmedical_appointments"
-		],
+		"includes": ["#__spmedical_departments", "#__spmedical_specialists", "#__spmedical_appointments"],
 		"excludes": [],
 		"data_excludes": []
 	},
 	"spcampaign": {
 		"name": "SP Campaign",
-		"includes": [
-			"#__spcampaign_guests",
-			"#__spcampaign_campaigns"
-		],
+		"includes": ["#__spcampaign_guests", "#__spcampaign_campaigns"],
 		"excludes": [],
 		"data_excludes": []
 	}


### PR DESCRIPTION
Added the following tables

```
"#__sppagebuilder_comments",
"#__sppagebuilder_likes",
"#__sppagebuilder_versions"


```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added comments, likes, and versions tables to the SP Page Builder schema so they’re included in exports. Also cleaned up array formatting in a few sections with no behavior change.

- **New Features**
  - Added "#__sppagebuilder_comments", "#__sppagebuilder_likes", "#__sppagebuilder_versions" to `sppagebuilder.includes`.

- **Refactors**
  - Collapsed `spmoviedb`, `spmedical`, and `spcampaign` includes arrays to single-line for consistency.

<sup>Written for commit 753a556cf756192b32ffbc50267a14776847863a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

