### PR TITLE
Page builder version data exclude

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -118,7 +118,7 @@
 			"#__schemaorg"
 		],
 		"data_excludes": [
-			"#__sppagebuilder_versions"
+			
 		]
 	},
 	"easystore": {
@@ -193,7 +193,9 @@
 			"#__sppagebuilder_collection_imports"
 		],
 		"excludes": [],
-		"data_excludes": []
+		"data_excludes": [
+			"#__sppagebuilder_versions"
+		]
 	},
 	"easy_gallery": {
 		"name": "Easy Image Gallery",

--- a/schema.json
+++ b/schema.json
@@ -117,7 +117,9 @@
 			"#__users",
 			"#__schemaorg"
 		],
-		"data_excludes": []
+		"data_excludes": [
+			"#__sppagebuilder_versions"
+		]
 	},
 	"easystore": {
 		"name": "EasyStore",

--- a/schema.json
+++ b/schema.json
@@ -118,7 +118,6 @@
 			"#__schemaorg"
 		],
 		"data_excludes": [
-			
 		]
 	},
 	"easystore": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Exclude SP Page Builder version history from data exports by adding "#__sppagebuilder_versions" to `data_excludes` in schema.json. This reduces export size and avoids migrating transient history records.

- **Bug Fixes**
  - Corrected `data_excludes` placement under the `sppagebuilder` config.

<sup>Written for commit 864cab3bcdf81508e66f5c197456d6e424f24e7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

